### PR TITLE
Fix Linux build + a handful of other minor changes

### DIFF
--- a/.github/workflows/sdks.yml
+++ b/.github/workflows/sdks.yml
@@ -40,9 +40,22 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.9.5'
-    - name: Install blacktop/ipsw
+    - name: Install blacktop/ipsw                                 # Blacktop's brew tap doesn't support Linux currently
       run: |
-        sudo snap install ipsw                     # Blacktop's tap doesn't support Linux currently
+        git clone https://github.com/blacktop/ipsw
+        cd ipsw
+        curl -L https://github.com/blacktop/ipsw/releases/latest/download/ipsw_"$(git describe --tags $(git rev-list --tags --max-count=1) | cut -c2-)"_linux_x86_64.deb -o ipsw.deb
+        sudo dpkg -i ipsw.deb
+        cd
+    - name: Install apfs-fuse
+      run: |
+        sudo apt update && sudo apt install -y libfuse3-dev
+        git clone --recursive https://github.com/sgan81/apfs-fuse
+        cd apfs-fuse
+        mkdir build && cd build
+        cmake ../
+        make -j$(nproc --all) install
+        cd
     - name: Set up python dependencies
       run: |
         python -m pip install --upgrade pip
@@ -70,7 +83,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v2
 
-      - name: Create Release                  # create a new release v1
+      - name: Create Release
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -86,7 +99,7 @@ jobs:
         run: |
           set -x
           assets=()
-          for asset in ./*; do               # loop the assets in the bin folder
+          for asset in ./*; do
             if [ -d "$asset" ]
             then
               zip -r $asset.zip $asset/

--- a/.github/workflows/sdks.yml
+++ b/.github/workflows/sdks.yml
@@ -25,9 +25,7 @@ jobs:
           - "13.7"
           - "13.6"
           - "13.5"
-          - "13.4.1"
           - "13.4"
-          - "13.2.2"
           - "13.2"
           - "13.1"
           - "13.0"
@@ -35,12 +33,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9.5'
-    - name: Install blacktop/ipsw                                 # Blacktop's brew tap doesn't support Linux currently
+    - name: Install blacktop/ipsw                             # Blacktop's brew tap doesn't support Linux currently
       run: |
         git clone https://github.com/blacktop/ipsw
         cd ipsw
@@ -62,26 +60,37 @@ jobs:
         pip install progressbar2 dyldextractor poetry
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         git clone https://github.com/cxnder/ktool.git && cd ktool && chmod +x dev_install.sh && ./dev_install.sh
-    - name: Building SDK
+    - name: Build SDK
       run: |
         python3 sdkgen.py ${{ matrix.version }}
-    - name: Compressing Artifact
+    - name: Prep SDK for artifact upload
       run: |
-        zip -r SDK.zip ${{ matrix.version }}.extracted
-    - name: Upload Zipped SDK
-      uses: actions/upload-artifact@v2.2.4
+        mv ${{ matrix.version }}.extracted iPhoneOS${{ matrix.version }}.sdk
+        zip -9 -r iPhoneOS${{ matrix.version }}.sdk.zip iPhoneOS${{ matrix.version }}.sdk
+    - name: Upload SDK artifact
+      uses: actions/upload-artifact@v3
       with:
-        name: ${{ matrix.version }}-SDK.zip
-        path: SDK.zip
+        name: ${{ matrix.version }}-Container
+        path: iPhoneOS${{ matrix.version }}.sdk.zip
 
 
   upload:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
+
+      - name: Extract SDKs from artifacts                     # SDKs get put into artifact-named directories by the artifact actions
+        run: |
+          set -x
+          mkdir sdks/
+          for container in ./*Container; do
+            if [[ -d "$container" ]]; then
+              mv $container/*.zip sdks/                       # Note: for some reason you can't cd into the artifact dirs?!
+            fi
+          done
 
       - name: Create Release
         id: create_release
@@ -89,21 +98,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: PRTEST
-          release_name: PRTEST
+          tag_name: Linux
+          release_name: Linux
           draft: false
           prerelease: false
-      - name: Attach binaries to release
+      - name: Attach SDKs to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -x
-          assets=()
-          for asset in ./*; do
-            if [ -d "$asset" ]
-            then
-              zip -r $asset.zip $asset/
-              assets+=("-a" "$asset.zip")
-            fi
+          sdks=()
+          for sdk in sdks/*.zip; do
+            sdks+=("-a" "$sdk")
           done
-          hub release edit "${assets[@]}" -m "PRTEST" "PRTEST"
+          hub release edit "${sdks[@]}" -m "Linux" "Linux"

--- a/sdkgen.py
+++ b/sdkgen.py
@@ -84,7 +84,7 @@ class DEAdapter:
     def extract_all(self, dsc_folder, output_folder):
         cwd = os.getcwd()
         os.chdir(dsc_folder)
-        system(f'dyldex_all -j 12 dyld_shared_cache_arm64')
+        system(f'dyldex_all -j$(nproc --all) dyld_shared_cache_arm64')
         system(f'mv binaries/System ./')
         os.chdir(cwd)
         system(f'mv {dsc_folder}/System/* {output_folder}')


### PR DESCRIPTION
Changes:
---
- Reverts blacktop/ipsw install to manual method (Snap install seems to be borked? and the Brew tap [doesn't support Linux yet](https://github.com/blacktop/homebrew-tap/issues/2))
- Removes two minor versions from build matrix (xx.x.#)
- Updates actions to latest versions
- Renames some of the steps for clarity 
- Removes a couple comments and adds a couple comments 
- Fixes double-zip artifact [issue](https://github.com/actions/upload-artifact/issues/39)
  - SDKs are now stored in an artifact "container" (a plain directory) and pulled from the container after being downloaded prior to being attached to the release 
  - This means the release files are now zips containing *just* the .sdk

This workflow has been tested and confirmed working on a sep branch: [here](https://github.com/L1ghtmann/sdk-builder/actions/runs/2790651088)